### PR TITLE
feat: Add ProfileCreatePage and SentenceArrangeComponent with routing…

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import CategorySelectionPage from "./src/pages/testPage";
 import WordSelectorPage from "./src/pages/WordSelectorPage";
 import QuizPage from "./src/pages/QuizPage";
 import Test2 from "./src/pages/test2";
+import ProfileCreatePage from "./src/pages/ProfileCreatePage";
 function App() {
   return (
     <AuthProvider>
@@ -50,6 +51,11 @@ function App() {
               <Route path="/words/:wordId/quizzes" element={
                 <ProtectedRoute>
                   <QuizPage />
+                </ProtectedRoute>
+              } />
+              <Route path="/profile" element={
+                <ProtectedRoute>
+                  <ProfileCreatePage />
                 </ProtectedRoute>
               } />
 

--- a/client/src/src/components/SentenceArrangeComponent.tsx
+++ b/client/src/src/components/SentenceArrangeComponent.tsx
@@ -1,0 +1,326 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Shuffle, RotateCcw, CheckCircle2, XCircle, GripVertical } from "lucide-react";
+import { useTranslate } from "../contexts/TranslateContext";
+
+// 🔤 Types
+export type LocalType = "en" | "fr" | "es" | "ar";
+
+type Props = {
+  questionId: string;
+  sentence: string; // phrase à mélanger
+  correctAnswer?: string; // si absent, on compare à `sentence`
+  fetchAnswer: (id: string, isCorrect: boolean) => Promise<string>;
+};
+
+// 🌍 Traductions locales
+const tr = {
+  fr: {
+    title: "Réarrange la phrase",
+    instruction: "Appuie sur les jetons pour construire la phrase dans le bon ordre.",
+    poolTitle: "Mots mélangés",
+    answerTitle: "Ta réponse",
+    placeholder: "Ta réponse apparaîtra ici…",
+    shuffle: "Mélanger",
+    clear: "Effacer",
+    validate: "Valider",
+    validating: "Validation…",
+    correct: "Bonne réponse !",
+    incorrect: "Mauvaise réponse.",
+  },
+  en: {
+    title: "Rearrange the sentence",
+    instruction: "Tap the tiles to build the sentence in the correct order.",
+    poolTitle: "Shuffled tiles",
+    answerTitle: "Your answer",
+    placeholder: "Your answer will appear here…",
+    shuffle: "Shuffle",
+    clear: "Clear",
+    validate: "Validate",
+    validating: "Validating…",
+    correct: "Correct answer!",
+    incorrect: "Incorrect answer.",
+  },
+  ar: {
+    title: "أعد ترتيب الجملة",
+    instruction: "اضغط على القطع لبناء الجملة بالترتيب الصحيح.",
+    poolTitle: "قطع عشوائية",
+    answerTitle: "إجابتك",
+    placeholder: "ستظهر إجابتك هنا…",
+    shuffle: "اعادة خلط",
+    clear: "مسح",
+    validate: "تحقّق",
+    validating: "جارٍ التحقق…",
+    correct: "إجابة صحيحة!",
+    incorrect: "إجابة خاطئة.",
+  },
+  es: {
+    title: "Reordena la frase",
+    instruction: "Toca las fichas para construir la frase en el orden correcto.",
+    poolTitle: "Fichas mezcladas",
+    answerTitle: "Tu respuesta",
+    placeholder: "Tu respuesta aparecerá aquí…",
+    shuffle: "Mezclar",
+    clear: "Borrar",
+    validate: "Validar",
+    validating: "Validando…",
+    correct: "¡Respuesta correcta!",
+    incorrect: "Respuesta incorrecta.",
+  },
+} as const;
+
+// 🔧 Utils
+type Token = { id: string; text: string };
+
+const PUNCT = new Set([".", ",", "!", "?", ";", ":", "…", "—", "–", "-", "\"", "'", "«", "»", ")", "]", "}"]); // ponctuation collée à gauche
+const OPEN_PUNCT = new Set(["(", "[", "{", "«"]); // ponctuation collée à droite
+
+function tokenize(input: string): string[] {
+  // coupe en mots/ponctuation; compatible langues latines + arabe via Unicode classes
+const re = /\p{L}[\p{L}\p{N}'’]*|\p{N}+|[.,!?;:…—–-]|["'«»()[\]{}]/gu;
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(input)) !== null) out.push(m[0]);
+  return out.length ? out : input.trim().split(/\s+/);
+}
+
+function joinTokens(tokens: string[]): string {
+  let s = "";
+  for (const tok of tokens) {
+    if (s.length === 0) {
+      s = tok;
+      continue;
+    }
+    if (PUNCT.has(tok)) {
+      // pas d'espace avant . , ! ? ; : … etc.
+      s += tok;
+    } else if (OPEN_PUNCT.has(tok)) {
+      // pas d'espace après ouvrants
+      s += tok;
+    } else if (PUNCT.has(s[s.length - 1])) {
+      // si le précédent est ponctuation ouvrante collée, pas d'espace
+      s += tok;
+    } else {
+      s += " " + tok;
+    }
+  }
+  return s;
+}
+
+function normalizeForCompare(s: string) {
+  return s
+    .replace(/\s+/g, " ")
+    .replace(/\s+([.,!?;:…])/g, "$1")
+    .replace(/([«(\[{])\s+/g, "$1")
+    .trim()
+    .toLowerCase();
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = arr.slice();
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+export default function SentenceArrangeComponent({ questionId, sentence, correctAnswer, fetchAnswer }: Props) {
+  const { language } = useTranslate();
+  type Keys = keyof typeof tr.fr;
+  const t = (key: Keys) => (tr as any)[language]?.[key] ?? tr.en[key];
+  const isRTL = language === "ar";
+
+  // Tokens de base
+  const baseTokens = useMemo(() => tokenize(correctAnswer ?? sentence), [sentence, correctAnswer]);
+  const [pool, setPool] = useState<Token[]>(() => shuffle(baseTokens).map((text, i) => ({ id: `${i}-${Math.random()}`, text })));
+  const [answer, setAnswer] = useState<Token[]>([]);
+
+  const [hasValidated, setHasValidated] = useState(false);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Reset quand la phrase change
+  useEffect(() => {
+    const shuffled = shuffle(baseTokens);
+    // éviter le même ordre que l'original
+    const isSame = JSON.stringify(shuffled) === JSON.stringify(baseTokens);
+    const final = isSame ? shuffle(shuffled) : shuffled;
+    setPool(final.map((text, i) => ({ id: `${i}-${Math.random()}`, text })));
+    setAnswer([]);
+    setHasValidated(false);
+    setIsCorrect(null);
+    setSubmitting(false);
+  }, [baseTokens.join("\u0001")]);
+
+  // Mouvements
+  const moveToAnswer = (token: Token) => {
+    if (hasValidated) return;
+    setPool((p) => p.filter((t) => t.id !== token.id));
+    setAnswer((a) => [...a, token]);
+  };
+  const moveToPool = (token: Token) => {
+    if (hasValidated) return;
+    setAnswer((a) => a.filter((t) => t.id !== token.id));
+    setPool((p) => [...p, token]);
+  };
+
+  // Drag & drop basique pour réordonner la réponse
+  const onDragStart = (e: React.DragEvent<HTMLButtonElement>, idx: number) => {
+    e.dataTransfer.setData("text/plain", String(idx));
+  };
+  const onDropReorder = (e: React.DragEvent<HTMLButtonElement>, idx: number) => {
+    e.preventDefault();
+    const from = Number(e.dataTransfer.getData("text/plain"));
+    if (Number.isNaN(from) || from === idx) return;
+    setAnswer((a) => {
+      const next = a.slice();
+      const [m] = next.splice(from, 1);
+      next.splice(idx, 0, m);
+      return next;
+    });
+  };
+
+  const handleValidate = async () => {
+    if (hasValidated) return;
+    const userSentence = joinTokens(answer.map((t) => t.text));
+    const target = correctAnswer ?? sentence;
+    const correct = normalizeForCompare(userSentence) === normalizeForCompare(target);
+
+    setHasValidated(true);
+    setIsCorrect(correct);
+
+    try {
+      setSubmitting(true);
+      await fetchAnswer(questionId, correct);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleShuffle = () => setPool((p) => shuffle(p));
+  const handleClear = () => {
+    if (hasValidated) return;
+    setPool((p) => [...p, ...answer]);
+    setAnswer([]);
+  };
+
+  const validateDisabled = submitting || answer.length !== baseTokens.length;
+
+  return (
+    <div className="w-full max-w-3xl mx-auto" dir={isRTL ? "rtl" : "ltr"}>
+      <div className="bg-white rounded-2xl shadow-2xl border border-[#F3F4F6] p-5 md:p-8">
+        {/* Header */}
+        <div className="mb-4">
+          <h2 className="text-lg md:text-xl font-semibold text-[#111827]">{t("title")}</h2>
+          <p className="text-sm text-[#111827]/70 mt-1">{t("instruction")}</p>
+        </div>
+
+        {/* Réponse (zone de construction) */}
+        <div className="mb-4">
+          <div className="text-sm font-semibold text-[#111827] mb-2">{t("answerTitle")}</div>
+          <div className="min-h-[64px] rounded-2xl border border-dashed border-[#F3F4F6] bg-[#F3F4F6] p-2 flex flex-wrap gap-2">
+            {answer.length === 0 && (
+              <span className="text-[#111827]/50 text-sm">{t("placeholder")}</span>
+            )}
+            {answer.map((tok, idx) => (
+              <button
+                key={tok.id}
+                draggable={!hasValidated}
+                onDragStart={(e) => onDragStart(e, idx)}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={(e) => onDropReorder(e, idx)}
+                type="button"
+                onClick={() => moveToPool(tok)}
+                className={[
+                  "inline-flex items-center gap-1 px-3 py-2 rounded-2xl",
+                  "bg-white text-[#111827] border border-[#E5E7EB] shadow-sm",
+                  "hover:scale-105 active:scale-95 transition",
+                ].join(" ")}
+                title={isRTL ? "إزالة" : "Remove"}
+              >
+                <GripVertical className="w-3.5 h-3.5 text-[#111827]/40" />
+                <span className="text-sm font-medium">{tok.text}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Jetons mélangés */}
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-semibold text-[#111827]">{t("poolTitle")}</span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleShuffle}
+                className="px-3 py-2 rounded-xl bg-white border border-[#F3F4F6] shadow-sm text-sm text-[#111827] hover:scale-105 active:scale-95 transition inline-flex items-center gap-1"
+                title={t("shuffle")}
+              >
+                <Shuffle className="w-4 h-4" /> {t("shuffle")}
+              </button>
+              <button
+                type="button"
+                onClick={handleClear}
+                className="px-3 py-2 rounded-xl bg-white border border-[#F3F4F6] shadow-sm text-sm text-[#111827] hover:scale-105 active:scale-95 transition inline-flex items-center gap-1"
+                title={t("clear")}
+              >
+                <RotateCcw className="w-4 h-4" /> {t("clear")}
+              </button>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {pool.map((tok) => (
+              <button
+                key={tok.id}
+                type="button"
+                onClick={() => moveToAnswer(tok)}
+                className={[
+                  "px-3 py-2 rounded-2xl bg-white text-[#111827] border border-[#F3F4F6] shadow-sm",
+                  "hover:scale-105 active:scale-95 transition text-sm font-medium",
+                ].join(" ")}
+              >
+                {tok.text}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Feedback */}
+        {hasValidated && (
+          <div
+            className={[
+              "w-full py-3 px-4 rounded-2xl border shadow-md flex items-center gap-2 mb-4",
+              isCorrect ? "bg-green-50 border-green-600" : "bg-red-50 border-red-600",
+            ].join(" ")}
+            role="status"
+            aria-live="polite"
+          >
+            {isCorrect ? (
+              <CheckCircle2 className="w-5 h-5 text-[#22C55E]" />
+            ) : (
+              <XCircle className="w-5 h-5 text-red-600" />
+            )}
+            <span className="text-[#111827] font-medium">
+              {isCorrect ? t("correct") : t("incorrect")}
+            </span>
+          </div>
+        )}
+
+        {/* Action principale */}
+        <button
+          type="button"
+          onClick={handleValidate}
+          disabled={validateDisabled}
+          className={[
+            "w-full py-3 px-6 rounded-2xl shadow-md text-white text-lg",
+            "transition hover:scale-105 active:scale-95",
+            validateDisabled ? "bg-[#3B82F6]/60 cursor-not-allowed" : "bg-[#3B82F6]",
+          ].join(" ")}
+        >
+          {submitting ? t("validating") : t("validate")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/src/pages/ProfileCreatePage.tsx
+++ b/client/src/src/pages/ProfileCreatePage.tsx
@@ -1,0 +1,255 @@
+import React, { useMemo, useState } from "react";
+import { CheckCircle2, Globe2, Moon, SunMedium, Loader2 } from "lucide-react";
+import { useTranslate } from "../contexts/TranslateContext"; // ✅ assure-toi que ce context expose { language, setLanguage }
+// ⛏️ Ajuste ce chemin selon ton arborescence
+import { createProfile } from "../../services/profile.services";
+import { useAuth } from "../contexts/AuthContext";
+
+// --- Types minimalistes côté front ---
+export type LocalType = "fr" | "es" | "ar";
+export type ThemeType = "light" | "dark";
+
+interface Props {
+  userId?: string; // si non fourni, on essaiera de le lire dans localStorage("userId")
+  onCreated?: (profile: { id: string; userId: string; local: LocalType; theme: ThemeType }) => void;
+}
+
+// 🌍 Traductions locales (fr/en/ar/es)
+const tr = {
+  fr: {
+    title: "Créer mon profil",
+    subtitle: "Choisis ta langue secondaire pour apprendre l'anglais.",
+    language: "Langue",
+    theme: "Thème",
+    light: "Clair",
+    dark: "Sombre",
+    save: "Enregistrer",
+    saving: "Enregistrement...",
+    success: "Profil créé avec succès !",
+    needUser: "Utilisateur introuvable. Connecte-toi d’abord.",
+    preview: "Aperçu",
+    helperLang: "Tu pourras modifier ces préférences plus tard.",
+  },
+  en: {
+    title: "Create my profile",
+    subtitle: "Choose your secondary language to learn English.",
+    language: "Language",
+    theme: "Theme",
+    light: "Light",
+    dark: "Dark",
+    save: "Save",
+    saving: "Saving...",
+    success: "Profile created successfully!",
+    needUser: "User not found. Please sign in first.",
+    preview: "Preview",
+    helperLang: "You can change these later.",
+  },
+  ar: {
+    title: "إنشاء ملفي الشخصي",
+    subtitle: "اختر لغتك الثانوية لتعلم الإنجليزية.",
+    language: "اللغة",
+    theme: "السمة",
+    light: "فاتح",
+    dark: "داكن",
+    save: "حفظ",
+    saving: "جارٍ الحفظ...",
+    success: "تم إنشاء الملف الشخصي بنجاح!",
+    needUser: "المستخدم غير موجود. يرجى تسجيل الدخول أولاً.",
+    preview: "معاينة",
+    helperLang: "يمكنك تغيير هذه الإعدادات لاحقًا.",
+  },
+  es: {
+    title: "Crear mi perfil",
+    subtitle: "Elige tu idioma secundario para aprender inglés.",
+    language: "Idioma",
+    theme: "Tema",
+    light: "Claro",
+    dark: "Oscuro",
+    save: "Guardar",
+    saving: "Guardando...",
+    success: "¡Perfil creado con éxito!",
+    needUser: "Usuario no encontrado. Inicia sesión primero.",
+    preview: "Vista previa",
+    helperLang: "Podrás cambiar esto más tarde.",
+  },
+} as const;
+
+export default function ProfileCreatePage({ userId, onCreated }: Props) {
+  const { language, setLanguage } = useTranslate();
+  type Keys = keyof typeof tr.fr;
+  const t = (key: Keys) => (tr as any)[language]?.[key] ?? tr.en[key];
+  const isRTL = language === "ar";
+    const { user } = useAuth();
+
+  const [local, setLocal] = useState<LocalType>((language as LocalType) ?? "en");
+  const [theme, setTheme] = useState<ThemeType>("light");
+  const [loading, setLoading] = useState(false);
+  const [ok, setOk] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setOk(null);
+    setErr(null);
+
+
+    setLoading(true);
+    try {
+      // ⚠️ le backend attend { userId, local, theme }
+      const payload = { userId: user?.id, local, theme } as const;
+      const created = await createProfile(payload as any);
+
+      setOk(created.message?.[language] );
+      // mettre à jour l’UI (langue du context)
+      try { setLanguage?.(local); } catch {}
+      // appliquer le thème côté document
+      try {
+        document.documentElement.classList.toggle("dark", theme === "dark");
+      } catch {}
+
+      onCreated?.(created);
+      // Optionnel: rediriger après 800ms
+      // setTimeout(() => navigate("/dashboard"), 800);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#F3F4F6] flex items-center justify-center p-4" dir={isRTL ? "rtl" : "ltr"}>
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-xl bg-white rounded-2xl shadow-2xl border border-[#F3F4F6] p-6 md:p-8"
+      >
+        {/* Header */}
+        <div className="mb-6">
+          <h1 className="text-2xl md:text-3xl font-bold text-[#111827]">{t("title")}</h1>
+          <p className="text-[#111827]/70 mt-1">{t("subtitle")}</p>
+        </div>
+
+        {/* Langue */}
+        <div className="mb-5">
+          <label className="block text-sm font-semibold text-[#111827] mb-2" htmlFor="local">
+            {t("language")}
+          </label>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2" id="local">
+            {([
+              { code: "fr", label: "Français" },
+              { code: "es", label: "Español" },
+              { code: "ar", label: "العربية" },
+            ] as { code: LocalType; label: string }[]).map(({ code, label }) => (
+              <button
+                type="button"
+                key={code}
+                onClick={() => setLocal(code)}
+                className={[
+                  "py-3 px-4 rounded-2xl border shadow-md text-sm font-medium",
+                  "transition hover:scale-105 active:scale-95",
+                  local === code
+                    ? "bg-[#3B82F6] text-white border-[#3B82F6]"
+                    : "bg-white text-[#111827] border-[#F3F4F6]",
+                ].join(" ")}
+                aria-pressed={local === code}
+              >
+                <span className="inline-flex items-center gap-2"><Globe2 className="w-4 h-4" />{label}</span>
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-[#111827]/60 mt-2">{t("helperLang")}</p>
+        </div>
+
+        {/* Thème */}
+        <div className="mb-6">
+          <span className="block text-sm font-semibold text-[#111827] mb-2">{t("theme")}</span>
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => setTheme("light")}
+              className={[
+                "py-3 px-4 rounded-2xl border shadow-md flex items-center justify-center gap-2",
+                "transition hover:scale-105 active:scale-95",
+                theme === "light"
+                  ? "bg-[#22C55E] text-white border-[#22C55E]"
+                  : "bg-white text-[#111827] border-[#F3F4F6]",
+              ].join(" ")}
+              aria-pressed={theme === "light"}
+            >
+              <SunMedium className="w-4 h-4" /> {t("light")}
+            </button>
+            <button
+              type="button"
+              onClick={() => setTheme("dark")}
+              className={[
+                "py-3 px-4 rounded-2xl border shadow-md flex items-center justify-center gap-2",
+                "transition hover:scale-105 active:scale-95",
+                theme === "dark"
+                  ? "bg-[#111827] text-white border-[#111827]"
+                  : "bg-white text-[#111827] border-[#F3F4F6]",
+              ].join(" ")}
+              aria-pressed={theme === "dark"}
+            >
+              <Moon className="w-4 h-4" /> {t("dark")}
+            </button>
+          </div>
+        </div>
+
+        {/* Aperçu */}
+        <div className="mb-6">
+          <span className="block text-sm font-semibold text-[#111827] mb-2">{t("preview")}</span>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="p-4 rounded-2xl border border-[#F3F4F6] shadow-sm bg-white">
+              <div className="text-xs text-[#111827]/70 mb-1">UI</div>
+              <div className="h-2 w-full bg-[#F3F4F6] rounded-full overflow-hidden">
+                <div className="h-full bg-[#22C55E] rounded-full" style={{ width: "60%" }} />
+              </div>
+              <div className="mt-3 h-10 rounded-xl bg-[#3B82F6] text-white grid place-items-center text-sm">
+                CTA
+              </div>
+            </div>
+            <div className={["p-4 rounded-2xl border shadow-sm", theme === "dark" ? "bg-[#111827] border-[#111827] text-white" : "bg-white border-[#F3F4F6] text-[#111827]"].join(" ") }>
+              <div className="text-xs opacity-70 mb-1">{theme === "dark" ? "Dark" : "Light"}</div>
+              <div className={"h-2 w-full rounded-full overflow-hidden " + (theme === "dark" ? "bg-white/20" : "bg-[#F3F4F6]") }>
+                <div className={"h-full rounded-full " + (theme === "dark" ? "bg-[#22C55E]" : "bg-[#22C55E]") } style={{ width: "40%" }} />
+              </div>
+              <div className={"mt-3 h-10 rounded-xl grid place-items-center text-sm " + (theme === "dark" ? "bg-white/10 text-white" : "bg-[#3B82F6] text-white") }>
+                Button
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Messages */}
+        {err && (
+          <div className="mb-3 p-3 rounded-2xl border border-red-200 bg-red-50 text-red-700 text-sm">
+            {err}
+          </div>
+        )}
+        {ok && (
+          <div className="mb-3 p-3 rounded-2xl border border-green-200 bg-green-50 text-[#111827] text-sm flex items-center gap-2">
+            <CheckCircle2 className="w-4 h-4 text-[#22C55E]" /> {ok}
+          </div>
+        )}
+
+        {/* Bouton principal (mobile-first) */}
+        <button
+          type="submit"
+          disabled={ loading}
+          className={[
+            "w-full py-3 px-6 rounded-2xl shadow-md text-white text-lg",
+            "transition hover:scale-105 active:scale-95",
+            loading ? "bg-[#3B82F6]/60 cursor-not-allowed" : "bg-[#3B82F6]",
+          ].join(" ")}
+        >
+          {loading ? (
+            <span className="inline-flex items-center gap-2"><Loader2 className="w-5 h-5 animate-spin" /> {t("saving")}</span>
+          ) : (
+            t("save")
+          )}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/client/src/src/pages/test2.tsx
+++ b/client/src/src/pages/test2.tsx
@@ -1,133 +1,249 @@
-import React, { useState } from "react";
-import QuestionComponent from "../components/QuestionComponent";
-import TTSQuestionComponent from "../components/AudioComponent";
+import React, { useMemo, useState } from "react";
+import { RotateCcw, Shuffle, StepForward, Globe2, CheckCircle2 } from "lucide-react";
+import { useTranslate } from "../contexts/TranslateContext"; // ⚠️ ajuste le chemin si besoin
+import SentenceArrangeComponent from "../components/SentenceArrangeComponent"; // ⚠️ ajuste le chemin si besoin
 
-interface Question {
-  id: string;
-  question: string;
-  options: string[];
-  correctAnswer: string;
-}
-
-const sampleQuestion: Question[] = [
-  {
-    id: "1",
-    question: "Quelle est la capitale de la France ?",
-    options: ["Berlin", "Madrid", "Paris", "Rome"],
-    correctAnswer: "Paris",
-  },
-  {
-    id: "2",
-    question: "Quel est le plus grand océan du monde ?",
-    options: ["Atlantique", "Indien", "Arctique", "Pacifique"],
-    correctAnswer: "Pacifique",
-  },
-  {
-    id: "3",
-    question: "Qui a écrit 'Les Misérables' ?",
-    options: [
-      "Victor Hugo",
-      "Émile Zola",
-      "Charles Baudelaire",
-      "Gustave Flaubert",
-    ],
-    correctAnswer: "Victor Hugo",
-  },
-];
-
-const sampleAudioQuestion = [{
-  id: "audio1",
-  question: "Choisir la trudiction du mot cheval.",
-  options: [
-    "Horse",
-    "Dog",
-    "Cat",
-    "Bird"
+// ————————————————————————————————————————————————————————
+// Données de démo (phrases à réarranger)
+// ————————————————————————————————————————————————————————
+const samples: Record<string, { id: string; sentence: string }[]> = {
+  en: [
+    { id: "en-1", sentence: "I am learning English every day." },
+    { id: "en-2", sentence: "She drinks a cup of coffee in the morning." },
+    { id: "en-3", sentence: "They will visit London next summer." },
   ],
-  correctAnswer: "Horse",
-},
-{
-  id: "audio2",
-  question: "Choisir la trudiction du mot maison.",
-  options: [
-    "Car",
-    "House",
-    "Tree",
-    "River"
+  fr: [
+    { id: "fr-1", sentence: "Je pratique l'anglais tous les jours." },
+    { id: "fr-2", sentence: "Elle boit une tasse de café le matin." },
+    { id: "fr-3", sentence: "Nous irons à Paris cet été." },
   ],
-  correctAnswer: "House",
-}]
+  es: [
+    { id: "es-1", sentence: "Estudio inglés todos los días." },
+    { id: "es-2", sentence: "Ella toma una taza de café por la mañana." },
+    { id: "es-3", sentence: "Visitaremos Madrid el próximo verano." },
+  ],
+  ar: [
+    { id: "ar-1", sentence: "أدرسُ الإنجليزية كلَّ يومٍ." },
+    { id: "ar-2", sentence: "تشربُ كوبًا من القهوةِ في الصباح." },
+    { id: "ar-3", sentence: "سنزورُ القاهرةَ في الصيفِ القادم." },
+  ],
+};
+
+// ————————————————————————————————————————————————————————
+// Traductions locales (UI de la page)
+// ————————————————————————————————————————————————————————
+const tr = {
+  fr: {
+    title: "Playground — Réarrangeur de phrase",
+    subtitle: "Choisis un jeu d'exemples, change la langue d'interface, et teste le composant.",
+    chooseSet: "Jeu d'exemples",
+    langUI: "Langue UI",
+    score: "Score",
+    attempts: "tentatives",
+    correct: "correctes",
+    next: "Phrase suivante",
+    reshuffle: "Remélanger",
+    reset: "Réinitialiser",
+    successNote: "Bonne réponse !",
+  },
+  en: {
+    title: "Playground — Sentence Arranger",
+    subtitle: "Pick a sample set, switch UI language, and try the component.",
+    chooseSet: "Sample set",
+    langUI: "UI language",
+    score: "Score",
+    attempts: "attempts",
+    correct: "correct",
+    next: "Next sentence",
+    reshuffle: "Reshuffle",
+    reset: "Reset",
+    successNote: "Correct answer!",
+  },
+  ar: {
+    title: "ساحة تجريب — مُرتِّب الجُمل",
+    subtitle: "اختر مجموعة أمثلة وبدّل لغة الواجهة وجرب المكوِّن.",
+    chooseSet: "مجموعة الأمثلة",
+    langUI: "لغة الواجهة",
+    score: "النتيجة",
+    attempts: "محاولات",
+    correct: "صحيحة",
+    next: "الجملة التالية",
+    reshuffle: "إعادة خلط",
+    reset: "إعادة تعيين",
+    successNote: "إجابة صحيحة!",
+  },
+  es: {
+    title: "Playground — Ordenar Oraciones",
+    subtitle: "Elige un conjunto de ejemplos, cambia el idioma de la interfaz y prueba el componente.",
+    chooseSet: "Conjunto de ejemplos",
+    langUI: "Idioma de la UI",
+    score: "Puntuación",
+    attempts: "intentos",
+    correct: "correctas",
+    next: "Siguiente frase",
+    reshuffle: "Mezclar de nuevo",
+    reset: "Reiniciar",
+    successNote: "¡Respuesta correcta!",
+  },
+} as const;
 
 export default function Test2() {
-  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [score, setScore] = useState(0);
-  const [showScore, setShowScore] = useState(false);
+  const { language, setLanguage } = useTranslate();
+  type Keys = keyof typeof tr.fr;
+  const t = (key: Keys) => (tr as any)[language]?.[key] ?? tr.en[key];
+  const isRTL = language === "ar";
 
-  const fetchAnswer = async (id: string, isCorrect: boolean): Promise<string> => {
-    // Simule un appel API
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        if (isCorrect) {
-          setScore((prev) => prev + 1);
-          resolve("Correct! Bien joué.");
-        } else {
-          resolve("Incorrect. Réessaie la prochaine fois.");
-        }
-      }, 300);
-    });
+  // État du jeu
+  const [setLang, setSetLang] = useState<keyof typeof samples>("en");
+  const [index, setIndex] = useState(0);
+  const [refreshKey, setRefreshKey] = useState(0); // pour remonter le composant et remélanger
+  const [attempts, setAttempts] = useState(0);
+  const [correct, setCorrect] = useState(0);
+  const [lastCorrect, setLastCorrect] = useState<boolean | null>(null);
+
+  const current = useMemo(() => {
+    const list = samples[setLang];
+    const safeIndex = Math.min(index, list.length - 1);
+    return list[safeIndex];
+  }, [setLang, index]);
+
+  const onFetchAnswer = async (id: string, ok: boolean) => {
+    setAttempts((n) => n + 1);
+    setLastCorrect(ok);
+    if (ok) setCorrect((n) => n + 1);
+    return ok ? "ok" : "ko";
   };
 
-  const handleNextQuestion = () => {
-    const nextIndex = currentQuestionIndex + 1;
-    if (nextIndex < sampleAudioQuestion.length) {
-      setCurrentQuestionIndex(nextIndex);
-    } else {
-      setShowScore(true);
-    }
+  const nextSentence = () => {
+    const list = samples[setLang];
+    setIndex((i) => (i + 1) % list.length);
+    setRefreshKey((k) => k + 1);
+    setLastCorrect(null);
   };
 
-  const restart = () => {
-    setCurrentQuestionIndex(0);
-    setScore(0);
-    setShowScore(false);
+  const reshuffle = () => setRefreshKey((k) => k + 1);
+  const resetAll = () => {
+    setIndex(0);
+    setAttempts(0);
+    setCorrect(0);
+    setRefreshKey((k) => k + 1);
+    setLastCorrect(null);
   };
 
-  const current = sampleAudioQuestion[currentQuestionIndex];
+  const progress = attempts === 0 ? 0 : Math.round((correct / attempts) * 100);
 
   return (
-    <div className="min-h-screen bg-[#F3F4F6] flex flex-col items-center justify-center p-4 text-[#111827]">
-      <h1 className="text-3xl font-bold mb-6">Quiz de Culture Générale</h1>
-
-      {showScore ? (
-        <div className="bg-white p-6 rounded-2xl shadow-2xl text-center">
-          <h2 className="text-2xl font-semibold mb-4">Votre score</h2>
-          <p className="text-xl mb-6">
-            {score} / {sampleAudioQuestion.length}
-          </p>
-          <button
-            onClick={restart}
-            className="px-6 py-3 rounded-2xl bg-[#3B82F6] text-white shadow-md hover:scale-105 active:scale-95 transition"
-          >
-            Recommencer
-          </button>
+    <div className="min-h-screen bg-[#F3F4F6] p-4 md:p-8" dir={isRTL ? "rtl" : "ltr"}>
+      <div className="max-w-5xl mx-auto">
+        {/* Header */}
+        <div className="mb-6 md:mb-8 flex flex-col gap-2">
+          <h1 className="text-2xl md:text-3xl font-bold text-[#111827]">{t("title")}</h1>
+          <p className="text-[#111827]/70">{t("subtitle")}</p>
         </div>
-      ) : (
-        <>
-          {/* ✅ key force le remontage pour réinitialiser l'état interne */}
-          <TTSQuestionComponent
-            key={current.id}
-            question={current}
-            fetchAnswer={fetchAnswer}
+
+        {/* Barres de contrôle */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-6">
+          {/* Choix du set d'exemples */}
+          <div className="bg-white rounded-2xl shadow-2xl border border-[#F3F4F6] p-4">
+            <div className="text-sm font-semibold text-[#111827] mb-2">{t("chooseSet")}</div>
+            <div className="grid grid-cols-4 gap-2">
+              {(["en", "fr", "es", "ar"] as const).map((code) => (
+                <button
+                  key={code}
+                  type="button"
+                  onClick={() => { setSetLang(code); setIndex(0); setRefreshKey((k)=>k+1); setLastCorrect(null); }}
+                  className={[
+                    "py-2 px-3 rounded-2xl border shadow-sm text-sm",
+                    "transition hover:scale-105 active:scale-95",
+                    setLang === code ? "bg-[#3B82F6] text-white border-[#3B82F6]" : "bg-white text-[#111827] border-[#F3F4F6]",
+                  ].join(" ")}
+                >
+                  {code.toUpperCase()}
+                </button>
+              ))}
+            </div>
+            <div className="mt-2 text-xs text-[#111827]/60">{current.sentence}</div>
+          </div>
+
+          {/* Langue UI */}
+          <div className="bg-white rounded-2xl shadow-2xl border border-[#F3F4F6] p-4">
+            <div className="text-sm font-semibold text-[#111827] mb-2 inline-flex items-center gap-2">
+              <Globe2 className="w-4 h-4" /> {t("langUI")}
+            </div>
+            <div className="grid grid-cols-4 gap-2">
+              {(["en", "fr", "es", "ar"] as const).map((code) => (
+                <button
+                  key={code}
+                  type="button"
+                  onClick={() => setLanguage?.(code)}
+                  className={[
+                    "py-2 px-3 rounded-2xl border shadow-sm text-sm",
+                    "transition hover:scale-105 active:scale-95",
+                    language === code ? "bg-[#22C55E] text-white border-[#22C55E]" : "bg-white text-[#111827] border-[#F3F4F6]",
+                  ].join(" ")}
+                  aria-pressed={language === code}
+                >
+                  {code.toUpperCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Score */}
+          <div className="bg-white rounded-2xl shadow-2xl border border-[#F3F4F6] p-4 flex flex-col justify-between">
+            <div>
+              <div className="text-sm font-semibold text-[#111827] mb-2">{t("score")}</div>
+              <div className="text-sm text-[#111827]/80 mb-2">
+                {correct} / {attempts} {t("correct")} ({attempts} {t("attempts")})
+              </div>
+              <div className="h-2 w-full bg-[#F3F4F6] rounded-full overflow-hidden">
+                <div className="h-full bg-[#22C55E] rounded-full" style={{ width: `${progress}%` }} />
+              </div>
+            </div>
+            {lastCorrect && (
+              <div className="mt-3 inline-flex items-center gap-2 text-[#111827] text-sm">
+                <CheckCircle2 className="w-4 h-4 text-[#22C55E]" /> {t("successNote")}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Carte principale */}
+        <div className="bg-white rounded-2xl shadow-2xl border border-[#F3F4F6] p-4 md:p-6">
+          <SentenceArrangeComponent
+            key={`${current.id}-${refreshKey}`}
+            questionId={current.id}
+            sentence={current.sentence}
+            correctAnswer={current.sentence}
+            fetchAnswer={onFetchAnswer}
           />
 
-          <button
-            onClick={handleNextQuestion}
-            className="mt-4 px-6 py-3 rounded-2xl bg-[#3B82F6] text-white shadow-md hover:scale-105 active:scale-95 transition"
-          >
-            Question suivante
-          </button>
-        </>
-      )}
+          {/* Actions */}
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-2">
+            <button
+              type="button"
+              onClick={nextSentence}
+              className="w-full py-3 px-4 rounded-2xl bg-[#3B82F6] text-white shadow-md hover:scale-105 active:scale-95 transition inline-flex items-center justify-center gap-2"
+            >
+              <StepForward className="w-4 h-4" /> {t("next")}
+            </button>
+            <button
+              type="button"
+              onClick={reshuffle}
+              className="w-full py-3 px-4 rounded-2xl bg-white text-[#111827] border border-[#F3F4F6] shadow-md hover:scale-105 active:scale-95 transition inline-flex items-center justify-center gap-2"
+            >
+              <Shuffle className="w-4 h-4" /> {t("reshuffle")}
+            </button>
+            <button
+              type="button"
+              onClick={resetAll}
+              className="w-full py-3 px-4 rounded-2xl bg-white text-[#111827] border border-[#F3F4F6] shadow-md hover:scale-105 active:scale-95 transition inline-flex items-center justify-center gap-2"
+            >
+              <RotateCcw className="w-4 h-4" /> {t("reset")}
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This pull request introduces a new profile creation workflow and a sentence arrangement exercise to the frontend, along with a route update to support the new profile page. The main changes are the addition of the `ProfileCreatePage` for user onboarding and language/theme selection, and the new interactive `SentenceArrangeComponent` for language learning exercises. Routing in `App.tsx` is updated to include the new profile page, and both new components feature multi-language support and improved UI/UX.

**New Features**

* Added `ProfileCreatePage` component: Allows users to create a profile, select their secondary language (French, Spanish, Arabic), and choose between light/dark themes. Includes multi-language support and applies theme changes to the document.
* Added `SentenceArrangeComponent` component: Interactive exercise for rearranging sentences, with drag & drop, shuffled tokens, validation, and feedback. Supports multiple languages and RTL layout for Arabic.

**Routing Updates**

* Imported `ProfileCreatePage` in `App.tsx` to make it available for routing.
* Added protected `/profile` route in `App.tsx` for the new profile creation page, ensuring only authenticated users can access it.… and localization support