### PR TITLE
fix: Update CORS origin configuration to use env.DOMAIN instead of en…

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -48,7 +48,7 @@ app.use(compression());
 if (env.NODE_ENV === "production") {
   app.use(
     cors({
-      origin: env.DOMAIN_CLIENT,
+      origin: env.DOMAIN,
       credentials: true,
     })
   );


### PR DESCRIPTION
This pull request makes a small configuration adjustment to the CORS middleware in the application. The change updates the allowed origin from the client domain to the main domain in production environments.

* Updated the CORS configuration in `src/app.ts` to use `env.DOMAIN` instead of `env.DOMAIN_CLIENT` as the allowed origin in production.