### PR TITLE
fix: Update server log to use env.DOMAIN for dynamic URL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ database
 
     // 🚀 Lancement en HTTP
     http.createServer(app).listen(PORT, "0.0.0.0", () => {
-      console.log(`🚀 Server running at http://192.168.2.19:${PORT}`);
+      console.log(`🚀 Server running at ${env.DOMAIN}`);
       console.log(`Env mode: ${env.NODE_ENV}`);
     });
 


### PR DESCRIPTION
This pull request makes a minor update to the server startup log message to display the domain from the environment variable instead of a hardcoded IP address.

- Updated the server startup log in `src/index.ts` to use `env.DOMAIN` for displaying the running server's address instead of the fixed IP.