### PR TITLE
fix: Correct DOMAIN variable in verification email link

### DIFF
--- a/src/utils/emailService.ts
+++ b/src/utils/emailService.ts
@@ -41,7 +41,7 @@ export const sendVerificationEmail = async (
   verificationToken: string,
   userId: string
 ): Promise<void> => {
-  const verificationLink = `${env.DOMAIN2 || "http://localhost:5173"}/verify/${userId}/${verificationToken}`;
+  const verificationLink = `${env.DOMAIN || "http://localhost:5173"}/verify/${userId}/${verificationToken}`;
 
   const html = `
     <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">


### PR DESCRIPTION
This pull request updates the domain environment variable used for generating email verification links. The change ensures that the correct domain is used when constructing the verification URL.

- Changed the verification link in `sendVerificationEmail` to use the `DOMAIN` environment variable instead of `DOMAIN2` in `emailService.ts`.